### PR TITLE
Fix #3 - Do not delete /.zonecontrol/metadata.sock

### DIFF
--- a/sm-prepare-image
+++ b/sm-prepare-image
@@ -154,6 +154,9 @@ for file in ${touch_files[@]}; do
   each_file_in ${file} touch
 done
 
+# Remove this socket file explicitly:
+rm -f /.zonecontrol/metadata.sock || true
+
 # Make sure /var/ssh exists to hold SSH host keys
 [ -d /var/ssh ] || mkdir -p /var/ssh
 }

--- a/sm-prepare-image
+++ b/sm-prepare-image
@@ -154,9 +154,6 @@ for file in ${touch_files[@]}; do
   each_file_in ${file} touch
 done
 
-# Remove this socket file explicitly:
-rm -f /.zonecontrol/metadata.sock
-
 # Make sure /var/ssh exists to hold SSH host keys
 [ -d /var/ssh ] || mkdir -p /var/ssh
 }


### PR DESCRIPTION
Because in the latest smartos-live version /.zonecontrol is a read-only lofs we may not need to remove the socket file.